### PR TITLE
Get PCF data from STDIN

### DIFF
--- a/pcf2vpnc
+++ b/pcf2vpnc
@@ -95,23 +95,31 @@ sub writeVPNC($) {
     }
     return $text;
 }
+sub help($) {
+    my $n = shift;
+    print STDERR "$n converts VPN-config files from pcf to vpnc-format.\n";
+    print STDERR "Usage: $n <pcf file> [vpnc file]\n";
+    exit(1);
+}
 
+my $src = undef;
+help($0) if($#ARGV < 0);
 if (defined $ARGV[0]) {
-    my $src = new IO::File($ARGV[0]) || die "Unable to open file ".$ARGV[0]."\n";
-    if (defined $ARGV[1]) {
-	my $dst = new IO::File($ARGV[1], "w") || die "Unable to open file ".$ARGV[1]."\n";
-	$dst->write( writeVPNC(readPCF($src)) ) || die "Unable to write to file ".$ARGV[1]."\n";
-	$dst->close() || die "Unable to close file ".$ARGV[1]."\n";
-	printf STDERR "vpnc config written to '%s' with permissions '%04o'.\n", $ARGV[1], (stat($ARGV[1]))[2];
-	print  STDERR "Please take care of permissions.\n";
-    } else {
-	print writeVPNC(readPCF($src));
-    }
-    $src->close() || die "Unable to close file ".$ARGV[0]."\n";
-    if ($needs_cert) {
-	print STDERR "\nDon't forget to copy the needed certificate(s).\n\n";
-    }
+    if( $ARGV[0] eq "-h" || $ARGV[0] eq "--help" ){ help($0); }
+    elsif( $ARGV[0] eq "-" ){ $src = *STDIN{IO} }
+}
+
+$src = new IO::File($ARGV[0]) || die "Unable to open file ".$ARGV[0]."\n" if( ! defined $src );
+if (defined $ARGV[1]) {
+    my $dst = new IO::File($ARGV[1], "w") || die "Unable to open file ".$ARGV[1]."\n";
+    $dst->write( writeVPNC(readPCF($src)) ) || die "Unable to write to file ".$ARGV[1]."\n";
+    $dst->close() || die "Unable to close file ".$ARGV[1]."\n";
+    printf STDERR "vpnc config written to '%s' with permissions '%04o'.\n", $ARGV[1], (stat($ARGV[1]))[2];
+    print  STDERR "Please take care of permissions.\n";
 } else {
-    print STDERR "$0 converts VPN-config files from pcf to vpnc-format.\n";
-    print STDERR "Usage: $0 <pcf file> [vpnc file]\n";
+    print writeVPNC(readPCF($src));
+}
+$src->close() || die "Unable to close file ".$ARGV[0]."\n";
+if ($needs_cert) {
+    print STDERR "\nDon't forget to copy the needed certificate(s).\n\n";
 }

--- a/pcf2vpnc
+++ b/pcf2vpnc
@@ -99,6 +99,8 @@ sub help($) {
     my $n = shift;
     print STDERR "$n converts VPN-config files from pcf to vpnc-format.\n";
     print STDERR "Usage: $n <pcf file> [vpnc file]\n";
+    print STDERR "PCF data from input.\n";
+    print STDERR "Usage: $n - [vpnc file]\n";
     exit(1);
 }
 


### PR DESCRIPTION
Read the PCF data from standard input instead of reading from a *.pcf file. You can past it to console, from example: **cat <<EOF | perl pcf2vpnc.pl - test.vpnc**
